### PR TITLE
Add BrowserView default web-based display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CodexChessGame
 
-A simple command-line chess game for two players in hotseat mode. The project is written in Python using an MVC structure.
+A simple chess game for two players in hotseat mode. The project is written in Python using an MVC structure.
+By default the board is displayed in your web browser.
 
 ## Running the game
 

--- a/chess_game/controllers/game_controller.py
+++ b/chess_game/controllers/game_controller.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 from ..models.board import Board
 from ..models.piece import Piece
-from ..views.console_view import ConsoleView
+from ..views.base_view import BaseView
 
 
 class GameController:
     """Coordinates the interactions between view and model."""
 
-    def __init__(self, view: ConsoleView) -> None:
+    def __init__(self, view: BaseView) -> None:
         self.board = Board()
         self.view = view
         self.current_player = 'white'

--- a/chess_game/game.py
+++ b/chess_game/game.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from .controllers.game_controller import GameController
-from .views.console_view import ConsoleView
+from .views.browser_view import BrowserView
 
 
 def main() -> None:
-    view = ConsoleView()
+    view = BrowserView()
     controller = GameController(view)
     controller.run()
 

--- a/chess_game/views/__init__.py
+++ b/chess_game/views/__init__.py
@@ -1,0 +1,5 @@
+from .base_view import BaseView
+from .console_view import ConsoleView
+from .browser_view import BrowserView
+
+__all__ = ["BaseView", "ConsoleView", "BrowserView"]

--- a/chess_game/views/base_view.py
+++ b/chess_game/views/base_view.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..models.board import Board
+
+
+class BaseView(ABC):
+    """Abstract base class for all user interface views."""
+
+    @abstractmethod
+    def display_board(self, board: Board) -> None:
+        """Show the board state to the user."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def prompt_move(self, player: str) -> str:
+        """Ask the player for their move and return the raw input."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def invalid_input(self) -> None:
+        """Notify the user about invalid input."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def invalid_move(self) -> None:
+        """Notify the user about an invalid move."""
+        raise NotImplementedError

--- a/chess_game/views/browser_view.py
+++ b/chess_game/views/browser_view.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import webbrowser
+from typing import List
+
+from ..models.board import Board
+from .base_view import BaseView
+
+
+class BrowserView(BaseView):
+    """Displays the chess board in a web browser."""
+
+    def __init__(self, html_file: str = "board.html") -> None:
+        self.html_file = html_file
+        self.browser_opened = False
+
+    def display_board(self, board: Board) -> None:
+        html_content = self._generate_html(board)
+        with open(self.html_file, "w", encoding="utf-8") as file_handle:
+            file_handle.write(html_content)
+        if not self.browser_opened:
+            webbrowser.open(f"file://{os.path.abspath(self.html_file)}")
+            self.browser_opened = True
+
+    def prompt_move(self, player: str) -> str:
+        return input(f"{player} move (e.g., e2 e4) or 'quit': ")
+
+    def invalid_input(self) -> None:
+        print("Invalid input. Enter moves like 'e2 e4'.")
+
+    def invalid_move(self) -> None:
+        print("Invalid move. Try again.")
+
+    def _generate_html(self, board: Board) -> str:
+        state = board.board_state_for_display()
+        html_lines: List[str] = []
+        html_lines.append("<html><head><meta charset='utf-8'>")
+        html_lines.append("<style>")
+        html_lines.append("table { border-collapse: collapse; }")
+        html_lines.append(
+            "td { width: 40px; height: 40px; text-align: center; font-size: 24px; }"
+        )
+        html_lines.append(".light { background: #eee; }")
+        html_lines.append(".dark { background: #666; color: white; }")
+        html_lines.append("</style></head><body>")
+        html_lines.append("<table>")
+        for row in range(7, -1, -1):
+            html_lines.append("<tr>")
+            for col in range(8):
+                piece = state[row][col]
+                cell_class = "light" if (row + col) % 2 == 0 else "dark"
+                cell_content = "&nbsp;" if piece == "." else piece
+                html_lines.append(f"<td class='{cell_class}'>{cell_content}</td>")
+            html_lines.append("</tr>")
+        html_lines.append("</table></body></html>")
+        return "\n".join(html_lines)

--- a/chess_game/views/console_view.py
+++ b/chess_game/views/console_view.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import os
 from ..models.board import Board
+from .base_view import BaseView
 
 
-class ConsoleView:
+class ConsoleView(BaseView):
     """Handles command-line interaction with the user."""
 
     WHITE_BACKGROUND = "\033[47m"


### PR DESCRIPTION
## Summary
- create a BaseView interface for views
- implement BrowserView that shows the board in a browser
- export all views through `chess_game.views`
- set BrowserView as the default view
- update README to describe new default

## Testing
- `python -m py_compile $(git ls-files '*.py')`