### PR TITLE
Add selectable chess sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ pip install -r requirements.txt
 
 Once started, open `http://localhost:5000` in your browser.
 Click on a piece and then a target square to make a move. The move history appears next to the board.
+You can switch between available chess sets using the dropdown above the board. Simply add a new folder under `chess_game/assets/ChessSets` following the same file naming scheme as the included **Staunton** set and it will be available in the dropdown.

--- a/chess_game/models/chess_set_manager.py
+++ b/chess_game/models/chess_set_manager.py
@@ -1,0 +1,37 @@
+"""Manage available chess sets and provide paths to piece images."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+
+class ChessSetManager:
+    """Handles discovery of chess sets and image path generation."""
+
+    def __init__(self, assets_path: Path) -> None:
+        self.assets_path = assets_path
+        self.chess_sets_path = self.assets_path / "ChessSets"
+        self.available_sets = self._discover_sets()
+
+    def _discover_sets(self) -> List[str]:
+        if not self.chess_sets_path.exists():
+            return []
+        return [d.name for d in self.chess_sets_path.iterdir() if d.is_dir()]
+
+    def image_path_for(self, set_name: str, symbol: str) -> str:
+        """Return relative path to the piece image."""
+        piece_names = {
+            "k": "King",
+            "q": "Queen",
+            "r": "Rook",
+            "b": "Bishop",
+            "n": "Knight",
+            "p": "Pawn",
+        }
+        color_prefix = "W" if symbol.isupper() else "B"
+        piece_name = piece_names.get(symbol.lower(), "")
+        file_name = f"{color_prefix}_{piece_name}.png"
+        return os.path.join("ChessSets", set_name, file_name)
+


### PR DESCRIPTION
## Summary
- allow chess set selection by scanning assets/ChessSets
- display piece images and dropdown in `WebView`
- expose set selection routes in `WebController`
- document how to add new chess sets

## Testing
- `python -m py_compile $(git ls-files '*.py')`